### PR TITLE
Fixed (and improved) the testing rule for msi_json_arrayops

### DIFF
--- a/tests/msi_json_arrayops_test.r
+++ b/tests/msi_json_arrayops_test.r
@@ -6,7 +6,7 @@ myTestRule {
    *item2 = 'U123456-ru.nl';
    *item3 = '{"type":"PMID","id":"12345"}';
    *item4 = '{"type":"arXiv","id":"xyz/abc"}';
-   *item5 = '1';
+   *item5 = 'null';
    *item6 = 'true';
    *item7 = 'false';
    *item8 = '["DICOM","test"]';
@@ -14,53 +14,64 @@ myTestRule {
    ## build JSON array
    *size = 0;
    *ec = errorcode( msi_json_arrayops(*json_str, *item1, "add", *size) );
-   #*ec = errorcode( msi_json_arrayops(*json_str, *item2, "add", *size) );
+   *ec = errorcode( msi_json_arrayops(*json_str, *item2, "add", *size) );
    *ec = errorcode( msi_json_arrayops(*json_str, *item3, "add", *size) );
-   #*ec = errorcode( msi_json_arrayops(*json_str, *item4, "add", *size) );
-   #*ec = errorcode( msi_json_arrayops(*json_str, *item6, "add", *size) );
-   #*ec = errorcode( msi_json_arrayops(*json_str, *item7, "add", *size) );
+   *ec = errorcode( msi_json_arrayops(*json_str, *item4, "add", *size) );
    *ec = errorcode( msi_json_arrayops(*json_str, *item8, "add", *size) );
+   writeLine("stdout", "Check 1: adding new values to JSON array. Outcome:");
+   writeLine("stdout", "    *json_str size: *size");
 
-    # adding null does not supported? 
+   # adding 'null' is not supported and will not extend the JSON array
    *ec = errorcode( msi_json_arrayops(*json_str, *item5, "add", *size) );
+   writeLine("stdout", "Check 2: adding 'null' value to JSON array. Outcome:");
+   writeLine("stdout", "    *json_str size: *size");
 
-    # adding those will append additional boolean values to array 
+   # adding those will append additional boolean values to array
    *ec = errorcode( msi_json_arrayops(*json_str, *item6, "add", *size) );
    *ec = errorcode( msi_json_arrayops(*json_str, *item7, "add", *size) );
+   writeLine("stdout", "Check 3: adding boolean values to JSON array. Outcome:");
+   writeLine("stdout", "    *json_str size: *size");
 
-    # adding those will not change array because they have been presented in it
+   # adding those will not change array because they are already present in it
    *ec = errorcode( msi_json_arrayops(*json_str, *item1, "add", *size) );
    *ec = errorcode( msi_json_arrayops(*json_str, *item2, "add", *size) );
    *ec = errorcode( msi_json_arrayops(*json_str, *item3, "add", *size) );
    *ec = errorcode( msi_json_arrayops(*json_str, *item4, "add", *size) );
+   writeLine("stdout", "Check 4: adding pre-existing values to JSON array. Outcome:");
+   writeLine("stdout", "    *json_str size: *size");
 
-   writeLine("stdout", *json_str ++ " size: " ++ *size);
-
-   ## remove JSON object (rm/find)
+   # remove JSON object (rm/find)
    *ec = errorcode( msi_json_arrayops(*json_str, *item3, "rm", *size) );
-   writeLine("stdout", *json_str ++ " size: " ++ *size);
+   writeLine("stdout", "Check 5: removing 1 object from JSON array. Outcome:");
+   writeLine("stdout", "    *json_str size: *size");
 
-   #*idx = 0;
-   #*ec = errorcode( msi_json_arrayops(*json_str, *item5, "find", *idx) );
-   #writeLine("stdout", *json_str ++ " " ++ *item5 ++ " at idx: " ++ str(*idx));
+   # find operations
+   *idx = 0;
+   *ec = errorcode( msi_json_arrayops(*json_str, *item4, "find", *idx) );
+   writeLine("stdout", "Check 6: Finding index of object in JSON array. Outcome:");
+   writeLine("stdout", "    *json_str value '*item4' at idx: *idx");
 
-   #*ec = errorcode( msi_json_arrayops(*json_str, *item4, "find", *idx) );
-   #writeLine("stdout", *json_str ++ " " ++ *item4 ++ " at idx: " ++ str(*idx));
+   *ec = errorcode( msi_json_arrayops(*json_str, *item5, "find", *idx) );
+   writeLine("stdout", "Check 7: Finding index of object in JSON array. Outcome:");
+   writeLine("stdout", "    *json_str value '*item5' at idx: *idx");
 
-   #*ec = errorcode( msi_json_arrayops(*json_str, *item1, "find", *idx) );
-   #writeLine("stdout", *json_str ++ " " ++ *item1 ++ " at idx: " ++ str(*idx));
+   *ec = errorcode( msi_json_arrayops(*json_str, *item1, "find", *idx) );
+   writeLine("stdout", "Check 8: Finding index of object in JSON array. Outcome:");
+   writeLine("stdout", "    *json_str value '*item1' at idx: *idx");
 
-   #*ec = errorcode( msi_json_arrayops(*json_str, "", "size", *idx) );
-   #writeLine("stdout", *json_str ++ " size: " ++ str(*idx));
+   # size operation
+   *ec = errorcode( msi_json_arrayops(*json_str, "", "size", *idx) );
+   writeLine("stdout", "Check 9: Determine size of JSON array. Outcome:");
+   writeLine("stdout", "    *json_str max idx: *idx");
 
-   *mysize = 0;
-   *ec = errorcode( msi_json_arrayops(*json_str, "", "size", *mysize) );
-   writeLine("stdout", *json_str ++ " size: " ++ str(*mysize));
-
-   *idx = 1;
-   *item1 = "";
-   *ec = errorcode( msi_json_arrayops(*json_str, *item1, "get", *idx) );
-   writeLine("stdout", *json_str ++ " " ++ *item1 ++ " at idx: " ++ str(*idx));
+   # get operation
+   *idx = 0;
+   *item11 = "";
+   *ec = errorcode( msi_json_arrayops(*json_str, *item11, "get", *idx) );
+   writeLine("stdout", "Check 10: Get an object from the JSON array. Outcome:");
+   writeLine("stdout", "    *json_str value '*item11' retrieved from idx: *idx");
 
 }
+
 OUTPUT ruleExecOut
+


### PR DESCRIPTION
Hi guys, 

In the process of porting our Maastricht irods-microservices to iRODS 4.2.3 I noticed that the testing rule for msi_json_arrayops broke. 
When calling `irule -F msi_json_arrayops_test.r`, the following errors were displayed:

**in stdout:** 
```
ERROR: rcExecMyRule error.  status = -1822000 INVALID_ANY_CAST
```
**in rodsLog:** 

> ERROR: rsExecMyRule : -1822000, [-]	/tmp/tmpIhxPZi/server/re/include/irods_re_plugin.hpp:237:irods::error irods::pluggable_rule_engine<std::__1::tuple<> >::exec_rule_text(T &, const std::string &, msParamArray_t *, const std::string &, irods::callback) [T = std::__1::tuple<>] :  status [INVALID_ANY_CAST]  errno [] -- message [failed to extract exec_rule_text operation from instance [irods_rule_engine_plugin-irods_rule_language-instance] exception message [boost::bad_any_cast: failed conversion using boost::any_cast]]


I found out that this was caused by the string concatenation method that was being used by the original rule (i.e. the + operators in `writeLine("stdout", *json_str ++ " size: " ++ *size);`). Apparently, that's not supported anymore in the boost::any library that iRODS 4.2.3 uses.


Besides the bugfix, I also added some contextual messages that indicate which JSON array operation has just occurred.

Since you are using the same microservice, I think this fix can be valuable to you. 

Cheers,
Best regards,
Maarten
