### PR TITLE
YDA-6772: Fix using replica status for msiArchiveCreate

### DIFF
--- a/src/msiArchiveCreate.cc
+++ b/src/msiArchiveCreate.cc
@@ -259,7 +259,7 @@ static void dirDataObj(Archive* a, rsComm_t* rsComm, std::string coll, long long
     memset(&genQueryInp, '\0', sizeof(genQueryInp_t));
     snprintf(collQCond, MAX_NAME_LEN, "='%lld'", collId);
     addInxVal(&genQueryInp.sqlCondInp, COL_D_COLL_ID, collQCond);
-    addInxVal(&genQueryInp.sqlCondInp, COL_DATA_REPL_NUM, "='0'");
+    addInxVal(&genQueryInp.sqlCondInp, COL_D_REPL_STATUS, "='1'");
     addInxIval(&genQueryInp.selectInp, COL_DATA_NAME, 1);
     addInxIval(&genQueryInp.selectInp, COL_D_DATA_ID, 1);
     addInxIval(&genQueryInp.selectInp, COL_DATA_SIZE, 1);

--- a/vagrant/build/.env
+++ b/vagrant/build/.env
@@ -9,14 +9,16 @@ APT_IRODS_REPO_SIGNING_KEY_LOC=https://packages.irods.org/irods-signing-key.asc
 # Parameters of the iRODS apt repository.
 APT_IRODS_REPO_URL=https://packages.irods.org/apt/
 APT_IRODS_REPO_ARCHITECTURE=amd64
+# Keep Jammy as distribution even for Nobel image, as iRODS 4.3.4 is built with Jammy
 APT_IRODS_REPO_DISTRIBUTION=jammy
 APT_IRODS_REPO_COMPONENT=main
 
 # Packages to be installed (separated by whitespace).
 # Dependencies do not have to be listed. They are resolved by the script
-APT_GEN_PACKAGES="git vim make g++ libssl-dev libcurl4-openssl-dev libjansson-dev libuuid1 uuid-dev libarchive-dev"
+# Pin the versions of some libraries since alvistack/ubuntu image has newer versions that conflict with provisioning
+APT_GEN_PACKAGES="git vim make g++ libssl-dev libcurl4-openssl-dev libjansson-dev libuuid1 uuid-dev libarchive13t64=3.7.2-2ubuntu0.5 libzstd1=1.5.5+dfsg2-2build1.1 libxml2=2.9.14+dfsg-1.3ubuntu3.7 libarchive-dev"
 APT_IRODS_PACKAGES="irods-runtime irods-dev"
-APT_IRODS_EXTERNAL_PACKAGES="irods-externals-cmake3.21.4-0 irods-externals-clang13.0.0-0"
+APT_IRODS_EXTERNAL_PACKAGES="irods-externals-cmake3.21.4-0 irods-externals-clang13.0.1-0"
 
 # Parameters of Yum repository
 YUM_IRODS_REPO_SIGNING_KEY_LOC=https://packages.irods.org/irods-signing-key.asc

--- a/vagrant/build/Vagrantfile
+++ b/vagrant/build/Vagrantfile
@@ -41,8 +41,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       s.inline = "sudo hostnamectl hostname $1"
       s.args   = HOST
     end
-    dev.vm.provision "shell",
-      inline: "sudo timedatectl set-timezone Europe/Amsterdam"
+    dev.vm.provision "shell", inline: <<-SHELL
+      sudo timedatectl set-timezone Europe/Amsterdam
+      sudo rm -f /etc/apt/sources.list.d/home-alvistack.sources
+    SHELL
     dev.vm.provision "file", source: ".env", destination: "/tmp/irods-test.env"
     dev.vm.provision :shell, :path => 'install-microservices-build-env.sh', :args => "/tmp/irods-test.env"
   end

--- a/vagrant/build/install-microservices-build-env.sh
+++ b/vagrant/build/install-microservices-build-env.sh
@@ -55,8 +55,8 @@ then
 cat << ENDAPTREPO | sudo tee /etc/apt/sources.list.d/irods.list
 deb [arch=${APT_IRODS_REPO_ARCHITECTURE}] $APT_IRODS_REPO_URL $APT_IRODS_REPO_DISTRIBUTION $APT_IRODS_REPO_COMPONENT
 ENDAPTREPO
-  sudo apt update
-
+  sudo apt-get update
+  
   for package in $APT_IRODS_PACKAGES
   do echo "Installing package $package and its dependencies"
      sudo apt-get -y install "$package=${IRODS_VERSION}"
@@ -70,7 +70,7 @@ ENDAPTREPO
 
   for package in $APT_GEN_PACKAGES
   do echo "Installing package $package and its dependencies"
-     sudo apt-get -y install "$package"
+     sudo apt-get -y --allow-downgrades install "$package"
   done
 
 else


### PR DESCRIPTION
For the context: 

Compressing File with use of Archive Script leads to empty .tar file

After compressing files using the archive script, the script shows a successful archive, but the resulted compressed file (.tar) has no data objects inside(the only file is an index.json file, which contains the source directory info).

The cause is due to that msiArchiveCreate archives data objects with condition replica number = 0. And all the NFS migrated data objects have replica number != 0, as the 0 data objects were trimmed after the migration. Thus, any msi/tool that having hard-coded replica number as filter conditions will not do as expected.   

We plan to fix it and integrate to 2.0.3 for DGK prod env and 2.0.4 for other environments

**In addition, I have a compiled .deb file to be installed directly, if you want to test with it, please let me know**. 

Associated PR in yoda repo: https://github.com/UtrechtUniversity/yoda/pull/684